### PR TITLE
Refactor engine and add dry‑run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ The currently supported trading pools will be continuously expanded in the futur
 
 > **For successful arbitrage trades using this arbitrage bot, a 10% fee of the profit will be charged. If the arbitrage fails or there is no profit, the contract will not charge any fees.** For example, if you input 0.5 SOL and output 0.6 SOL, the profit is 0.1 SOL, and the fee is 0.1 * 10% = 0.01 SOL.
 
+## 🔧 Architecture Overview
+
+The repository is organised into several top level folders:
+
+- `core/` – stateless arbitrage engine orchestrating the flow
+- `dex_adapters/` – one module per DEX implementing a common interface
+- `contracts/` – on-chain program interaction code
+- `config/` – configuration files and validation helpers
+- `logger/` – centralised logging with daily rotation
+- `utils/` – pure utility helpers
+- `test/` – unit tests
+
+### Adding a new DEX adapter
+
+1. Create a class extending `DexAdapter` in `dex_adapters/`.
+2. Implement at least `initialize(connection)` and `fetchPools(mint)`.
+3. Optionally provide `createSwapTransaction(pools)` for transaction generation.
+4. Instantiate your adapter in `start.js`.
+
 ## 🚀 Quick Start
 
 ### Install the Environment

--- a/config/index.js
+++ b/config/index.js
@@ -1,6 +1,15 @@
 import fs from 'fs';
 import Joi from 'joi';
 
+/**
+ * @typedef {Object} Config
+ * @property {{rpcUrl:string,screctKey:number[],screctKeyBase58:string,guardContractIDL:string}} base
+ * @property {{maxInputAmount:number,minProfit:number,maxSendRate:number,maxIOConcurrent:number,skipPreflight:boolean,mintXExpirationTime:number}} bot
+ * @property {string[]} mintList
+ * @property {string[]} [address_lookup_tables]
+ * @property {boolean} dryRun
+ */
+
 const schema = Joi.object({
   base: Joi.object({
     rpcUrl: Joi.string().uri().required(),
@@ -24,7 +33,7 @@ const schema = Joi.object({
 /**
  * Load and validate configuration file.
  * @param {string} [path] Path to config JSON file.
- * @returns {object} validated configuration object
+ * @returns {Config} validated configuration object
  */
 export function loadConfig(path = new URL('./config.json', import.meta.url).pathname) {
   const raw = fs.readFileSync(path, 'utf8');

--- a/core/engine.js
+++ b/core/engine.js
@@ -1,9 +1,19 @@
 import { getLogger } from '../logger/index.js';
+import { PoolFetchError } from '../utils/errors.js';
 
 /**
  * Asynchronous arbitrage engine independent from concrete DEX.
  */
+/**
+ * Core orchestrator for arbitrage logic. The engine is stateless and can be
+ * instantiated multiple times across workers.
+ */
 export class ArbitrageEngine {
+  /**
+   * @param {import('../config/index.js').Config} config validated config
+   * @param {import('@solana/web3.js').Connection} connection Solana connection
+   * @param {Array<import('../dex_adapters/baseAdapter.js').DexAdapter>} adapters adapters to use
+   */
   constructor(config, connection, adapters) {
     this.config = config;
     this.connection = connection;
@@ -11,6 +21,10 @@ export class ArbitrageEngine {
     this.logger = getLogger();
   }
 
+  /**
+   * Initialize all adapters.
+   * @returns {Promise<void>}
+   */
   async initialize() {
     for (const adapter of this.adapters) {
       await adapter.initialize(this.connection);
@@ -18,16 +32,40 @@ export class ArbitrageEngine {
     this.logger.info('Engine initialized');
   }
 
+  /**
+   * Execute a single arbitrage cycle for the given mint.
+   * Public for testing purposes.
+   * @param {string} mint token mint address
+   * @returns {Promise<void>}
+   */
+  async processMint(mint) {
+    for (const adapter of this.adapters) {
+      try {
+        const pools = await adapter.fetchPools(mint);
+        this.logger.info(`${adapter.name} pools for ${mint}: ${pools?.length ?? 0}`);
+        if (pools.length) {
+          if (this.config.dryRun) {
+            this.logger.info(`Dry run: skipping tx creation for ${adapter.name}`);
+          } else {
+            await adapter.createSwapTransaction(pools);
+          }
+        }
+      } catch (e) {
+        this.logger.error(new PoolFetchError(adapter.name, e).message);
+      }
+    }
+  }
+
+  /**
+   * Start the continuous arbitrage loop.
+   * @returns {Promise<void>}
+   */
   async run() {
     await this.initialize();
     while (true) {
       try {
         for (const mint of this.config.mintList) {
-          for (const adapter of this.adapters) {
-            const pools = await adapter.fetchPools(mint);
-            this.logger.info(`${adapter.name} pools for ${mint}: ${pools?.length ?? 0}`);
-            // profit calculation & tx creation would happen here
-          }
+          await this.processMint(mint);
         }
       } catch (e) {
         this.logger.error(`Engine error: ${e.message}`);

--- a/dex_adapters/baseAdapter.js
+++ b/dex_adapters/baseAdapter.js
@@ -2,6 +2,9 @@
  * Base class for DEX adapters.
  */
 export class DexAdapter {
+  /**
+   * @param {string} name human readable adapter name
+   */
   constructor(name) {
     this.name = name;
   }
@@ -24,10 +27,11 @@ export class DexAdapter {
   }
 
   /**
-   * Create swap transactions (placeholder).
+   * Create swap transactions from a list of pools.
+   * @param {Array} pools fetched pool objects
    * @returns {Promise<void>}
    */
-  async createSwapTransaction() {
+  async createSwapTransaction(pools) {
     throw new Error('Not implemented');
   }
 }

--- a/dex_adapters/raydiumAdapter.js
+++ b/dex_adapters/raydiumAdapter.js
@@ -5,6 +5,9 @@ import { RaydiumPoolKeyFinder } from '../src/pool_finder/raydium_finder.js';
  * Raydium adapter using existing finder and fetcher logic.
  */
 export class RaydiumAdapter extends DexAdapter {
+  /**
+   * Create new adapter instance.
+   */
   constructor() {
     super('raydium');
     this.finder = new RaydiumPoolKeyFinder();
@@ -16,5 +19,13 @@ export class RaydiumAdapter extends DexAdapter {
     } catch (e) {
       return [];
     }
+  }
+
+  /**
+   * Placeholder transaction builder.
+   * @param {Array} _pools
+   */
+  async createSwapTransaction(_pools) {
+    // Implementation would create VersionedTransaction using fetched pools
   }
 }

--- a/logger/index.js
+++ b/logger/index.js
@@ -3,6 +3,10 @@ import 'winston-daily-rotate-file';
 
 let logger;
 
+/**
+ * Get shared logger instance.
+ * @returns {import('winston').Logger}
+ */
 export function getLogger() {
   if (logger) return logger;
 

--- a/test/dry_run.test.js
+++ b/test/dry_run.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'assert';
+import { Connection } from '@solana/web3.js';
+import { loadConfig } from '../config/index.js';
+import { ArbitrageEngine } from '../core/engine.js';
+import { DexAdapter } from '../dex_adapters/baseAdapter.js';
+
+class MockAdapter extends DexAdapter {
+  constructor() { super('mock'); this.called = false; }
+  async fetchPools() { return [1]; }
+  async createSwapTransaction() { this.called = true; }
+}
+
+test('dry run skips transaction creation', async () => {
+  const cfg = loadConfig();
+  cfg.dryRun = true;
+  const adapter = new MockAdapter();
+  const engine = new ArbitrageEngine(cfg, new Connection(cfg.base.rpcUrl), [adapter]);
+  await engine.processMint('mint');
+  assert.equal(adapter.called, false);
+});

--- a/utils/errors.js
+++ b/utils/errors.js
@@ -1,0 +1,22 @@
+export class ArbitrageError extends Error {
+  /**
+   * @param {string} message error message
+   */
+  constructor(message) {
+    super(message);
+    this.name = 'ArbitrageError';
+  }
+}
+
+/** Error thrown when fetching pools from a DEX fails. */
+export class PoolFetchError extends ArbitrageError {
+  /**
+   * @param {string} dexName DEX adapter name
+   * @param {Error} original original error
+   */
+  constructor(dexName, original) {
+    super(`Failed to fetch pools from ${dexName}: ${original.message}`);
+    this.name = 'PoolFetchError';
+    this.original = original;
+  }
+}


### PR DESCRIPTION
## Summary
- document project architecture in README
- define Config JSDoc type and update config loader
- implement stateless ArbitrageEngine with dry-run mode
- improve adapter classes with JSDoc
- centralize error types and logger docs
- add unit test for dry-run processing

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684586fdcd78832cbbec15078c3b21eb